### PR TITLE
callback need to know its container

### DIFF
--- a/jquery.freetile.js
+++ b/jquery.freetile.js
@@ -158,7 +158,7 @@
 
             // Generate the options object.
             var newOptions = $.extend(true,
-                {},
+                {container:container},
                 this.defaults,
                 containerData,
                 this.reset,


### PR DESCRIPTION
``` javascript
var defaults = {    
 selector: '.freetile__item',
 callback: function() {
   this.container.css('visiblility','visible').find('.freetile__item').css('visibility', 'visible');
}}
...
$('.freetile').each( function(){ $(this).freetile(defaults); } ); 
```
